### PR TITLE
Add new variable to configure reboot on change

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,9 @@ grub_recordfail_timeout: "{{ grub_timeout }}"
 grub_packages: "{{ _grub_packages[ansible_os_family] | default(_grub_packages['default']) }}"
 grub_update_grub_command: "{{ _grub_update_grub_command[ansible_os_family] | default(_grub_update_grub_command['default']) }}"
 
+# Define if the host must reboot on change
+grub_reboot_on_change: true
+
 # Add options here, for example:
 # grub_options:
 #   - option: cgroup_enable

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,6 +9,9 @@ grub_recordfail_timeout: "{{ grub_timeout }}"
 grub_packages: "{{ _grub_packages[ansible_os_family] | default(_grub_packages['default']) }}"
 grub_update_grub_command: "{{ _grub_update_grub_command[ansible_os_family] | default(_grub_update_grub_command['default']) }}"
 
+# Define if the host must reboot on change
+grub_reboot_on_change: true
+
 # Add options here, for example:
 # grub_options:
 #   - option: cgroup_enable

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -11,3 +11,4 @@
 
 - name: Reboot
   ansible.builtin.reboot:
+  when: grub_reboot_on_change


### PR DESCRIPTION
Previously, the host was rebooted on change. On some environments, it should be possible to configure Grub without having to immediatly reboot the hosts. Add new boolean `grub_reboot_on_change` that allow to avoid reboot in the handler. Default to `true` for backward compatibility.